### PR TITLE
updated setup.py to ship with license and weights

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,11 @@
 from setuptools import find_packages, setup
 
-setup(name="jax_unirep", version="0.1", packages=find_packages())
+setup(
+    name="jax_unirep",
+    version="0.1",
+    packages=find_packages(),
+    package_data={
+        '': ["LICENSE", "weights/*"],
+    },
+    include_package_data=True,
+)


### PR DESCRIPTION
We're going  to need to distribute the weights files. Having them referenced correctly is also important.