### PR TITLE
Changed return order of reps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ To generate representations of protein sequences,
 pass a list of sequences as strings or a single sequence to `jax_unirep.get_reps`.
 It will return a tuple consisting of the following representations for each sequence:
 
+- `h_avg`: Average hidden state of the mLSTM over the whole sequence.
 - `h_final`: Final hidden state of the mLSTM
 - `c_final`: Final cell state of the mLSTM
-- `h_avg`: Average hidden state of the mLSTM over the whole sequence.
 
 From the original paper, `h_avg` is considered the "representation" (or "rep") of the protein sequence.
 
@@ -57,7 +57,7 @@ from jax_unirep import get_reps
 sequence = "ASDFGHJKL"
 
 # h_avg is the canonical "reps"
-h_final, c_final, h_avg = get_reps(sequence)
+h_avg, h_final, c_final = get_reps(sequence)
 ```
 
 And for multiple sequences:
@@ -68,7 +68,7 @@ from jax_unirep import get_reps
 sequences = ["ASDF", "YJKAL", "QQLAMEHALQP"]
 
 # h_avg is the canonical "reps"
-h_final, c_final, h_avg = get_reps(sequences)
+h_avg, h_final, c_final= get_reps(sequences)
 
 # each of the arrays will be of shape (len(sequences), 1900),
 # with the correct order of sequences preserved


### PR DESCRIPTION
- Changed the return order of representations in `featurize.py` to match the original implementation. Intentionally left the return order in `layers.py` as is, because of the `lax.scan` API.