### PR TITLE
deleted "apply_fun" in get_rep() and added a comma to evotune example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ lr_config = {"low": 0.001, "high": 0.1}
 study, evotuned_params = evotune(
     sequences=sequences,
     n_trials=20, # how many trials optuna should do
-    params=None # defaults to weights from the paper
+    params=None, # defaults to weights from the paper
     n_epochs_config=n_epochs_config,
     learning_rate_config=lr_config
 )

--- a/jax_unirep/featurize.py
+++ b/jax_unirep/featurize.py
@@ -134,6 +134,6 @@ def get_reps(
         return h_avg, h_final, c_final
     else:
         h_avg, h_final, c_final = rep_arbitrary_lengths(
-            seqs, params, apply_fun
+            seqs, params
         )
         return h_avg, h_final, c_final


### PR DESCRIPTION
2 small changes: 1 to fix get_rep() for variable sequences, and a quick fix in the README with a missing comma for evotuning example.

Closes #32 