### PR TITLE
Fix params passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The [`evotune`][evotunefunc] function uses `optuna` under the hood
 to automatically find: 
 1. the optimal number of epochs to train for, and
 2.  the optimal learning rate, 
+
 given a set of sequences.
 The `study` object will contain all the information
 about the training process of each trial. 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ training process of each trial.
 `evotuned_params` will contain the fine-tuned mLSTM and dense weights 
 from the trial with the lowest test set loss.
 
-If you want to directly fine-tune the weights for a fixed number
-of epochs and with a fixed learning rate, you should use
-the [`fit`][fitfunc] function instead.
+If you want to directly fine-tune the weights
+for a fixed number of epochs
+while using a fixed learning rate,
+you should use the [`fit`][fitfunc] function instead.
 
 You can find an example usage of both functions [here][exampleevotune].
 

--- a/README.md
+++ b/README.md
@@ -91,36 +91,33 @@ Given a set of starter weights for the mLSTM (defaults to
 the weights from the paper) as well as a set of sequences,
 the weights get fine-tuned in such a way that test set loss
 in the 'next-aa prediction task' is minimized.
-In order to achieve this, `optuna` is used to
-find the optimal number of epochs to train for as well as the
-optimal learning rate.
-Example usage:
+There are two functions with differing levels of
+control available for the task.
+
+The [`evotune`][evotunefunc] function uses `optuna` under the hood, to automatically
+find the optimal number of epochs to train for given a set of sequences,
+as well as the optimal learning rate. 
+The `study` object will contain all the information about the
+training process of each trial. 
+`evotuned_params` will contain the fine-tuned mLSTM and dense weights 
+from the trial with the lowest test set loss.
+
+If you want to directly fine-tune the weights for a fixed number
+of epochs and with a fixed learning rate, then you should use
+the [`fit`][fitfunc] function.
+
+You can find an example usage of both functions [here][exampleevotune]
+
+If you want to pass a set of mLSTM and dense weights that were
+dumped in an earlier run, create params as follows:
 
 ```python
-from jax_unirep import evotune
+from jax_unirep.utils import load_params
 
-sequences = ["ASDF", "YJKAL", "QQLAMEHALQP", ...]
-
-# parameters for optuna need to be passed in form of a dictionary
-# the range of epochs and learning rates to try can be adapted this way
-n_epochs_config = {"low": 5, "high": 10}
-lr_config = {"low": 0.001, "high": 0.1}
-
-study, evotuned_params = evotune(
-    sequences=sequences,
-    n_trials=20, # how many trials optuna should do
-    params=None, # defaults to weights from the paper
-    n_epochs_config=n_epochs_config,
-    learning_rate_config=lr_config
-)
+params = load_params(folderpath="path/to/params/folder")
 ```
 
-The `study` object will contain all the information about the
-training process of each trial. `evotuned_params` will contain the
-fine-tuned weights from the trial with the lowest test set loss.
-
-In order to start from randomly initialized mLSTM weights instead,
-create `params` as follows:
+If you want to start from randomly initialized mLSTM and dense weights instead:
 
 ```python
 from jax_unirep.evotuning import init_fun
@@ -129,8 +126,10 @@ from jax.random import PRNGKey
 _, params = init_fun(PRNGKey(0), input_shape=(-1, 10))
 ```
 
-In principle, any set of weights which is compatible
-with the mLSTM `init_fun` in `jax_unirep.layers` can be passed.
+The weights used in the 10-dimensional embedding
+of the input sequences always default to the 
+weights from the paper, since they do not
+get updated during evotuning.
 
 ### UniRep stax
 
@@ -181,5 +180,8 @@ is licensed under the terms of [GPL v3][gpl3].
 [ericmjl]: https://github.com/ericmjl
 [fundl]: https://github.com/ericmjl/fundl
 [gpl3]: https://www.gnu.org/licenses/gpl-3.0.html
+[evotunefunc]: https://github.com/ElArkk/jax-unirep/blob/master/jax_unirep/evotuning.py#L417
+[fitfunc]: https://github.com/ElArkk/jax-unirep/blob/master/jax_unirep/evotuning.py#L164
+[exampleevotune]: https://github.com/ElArkk/jax-unirep/blob/master/examples/evotuning.py
 [stax]: https://jax.readthedocs.io/en/latest/jax.experimental.stax.html
 [staxex]: https://github.com/google/jax/tree/master/examples

--- a/README.md
+++ b/README.md
@@ -94,11 +94,13 @@ in the 'next-aa prediction task' is minimized.
 There are two functions with differing levels of
 control available for the task.
 
-The [`evotune`][evotunefunc] function uses `optuna` under the hood, to automatically
-find the optimal number of epochs to train for given a set of sequences,
-as well as the optimal learning rate. 
-The `study` object will contain all the information about the
-training process of each trial. 
+The [`evotune`][evotunefunc] function uses `optuna` under the hood
+to automatically find: 
+1. the optimal number of epochs to train for, and
+2.  the optimal learning rate, 
+given a set of sequences.
+The `study` object will contain all the information
+about the training process of each trial. 
 `evotuned_params` will contain the fine-tuned mLSTM and dense weights 
 from the trial with the lowest test set loss.
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ the [`fit`][fitfunc] function instead.
 
 You can find an example usage of both functions [here][exampleevotune].
 
-If you want to pass a set of mLSTM and dense weights that were
-dumped in an earlier run, create params as follows:
+If you want to pass a set of mLSTM and dense weights
+that were dumped in an earlier run,
+create params as follows:
 
 ```python
 from jax_unirep.utils import load_params

--- a/README.md
+++ b/README.md
@@ -126,10 +126,9 @@ from jax.random import PRNGKey
 _, params = init_fun(PRNGKey(0), input_shape=(-1, 10))
 ```
 
-The weights used in the 10-dimensional embedding
-of the input sequences always default to the 
-weights from the paper, since they do not
-get updated during evotuning.
+The weights used in the 10-dimensional embedding of the input sequences
+always default to the weights from the paper,
+since they do not get updated during evotuning.
 
 ### UniRep stax
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ Given a set of starter weights for the mLSTM (defaults to
 the weights from the paper) as well as a set of sequences,
 the weights get fine-tuned in such a way that test set loss
 in the 'next-aa prediction task' is minimized.
-There are two functions with differing levels of
-control available for the task.
+There are two functions with differing levels of control available.
 
 The [`evotune`][evotunefunc] function uses `optuna` under the hood
 to automatically find: 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ There are two functions with differing levels of control available.
 The [`evotune`][evotunefunc] function uses `optuna` under the hood
 to automatically find: 
 1. the optimal number of epochs to train for, and
-2.  the optimal learning rate, 
+2. the optimal learning rate, 
 
 given a set of sequences.
 The `study` object will contain all the information

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ training process of each trial.
 from the trial with the lowest test set loss.
 
 If you want to directly fine-tune the weights for a fixed number
-of epochs and with a fixed learning rate, then you should use
-the [`fit`][fitfunc] function.
+of epochs and with a fixed learning rate, you should use
+the [`fit`][fitfunc] function instead.
 
-You can find an example usage of both functions [here][exampleevotune]
+You can find an example usage of both functions [here][exampleevotune].
 
 If you want to pass a set of mLSTM and dense weights that were
 dumped in an earlier run, create params as follows:

--- a/examples/evotuning.py
+++ b/examples/evotuning.py
@@ -1,7 +1,6 @@
 """Evotuning two ways."""
 from jax_unirep import evotune, fit
-from jax_unirep.params import add_dense_params
-from jax_unirep.utils import dump_params, load_params_1900
+from jax_unirep.utils import dump_params
 
 # Test sequences:
 sequences = ["HASTA", "VISTA", "ALAVA", "LIMED", "HAST", "HAS", "HASVASTA"] * 5

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -488,8 +488,9 @@ def evotune(
         See source code for default configuration,
         at the definition of ``learning_rate_kwargs``.
     :param n_splits: The number of folds of cross-validation to do.
-    :param steps_per_print: the number of steps between each print,
-        will print out current evotuned_params.
+    :param steps_per_print: The number of steps between each
+        printing and dumping of weights in the final
+        evotuning step using the optimized hyperparameters.
 
     :returns:
         - study - The optuna study object, containing information

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -167,7 +167,7 @@ def fit(
     step_size: float = 0.001,
     holdout_seqs: Optional[List[str]] = None,
     proj_name: Optional[str] = "temp",
-    steps_per_print: Optional[int] = None,
+    steps_per_print: Optional[int] = 200,
 ) -> Dict:
     """
     Return weights fitted to predict the next letter in each sequence.

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -23,9 +23,8 @@ from .utils import (
     dump_params,
     get_batch_len,
     get_embeddings,
-    load_dense_1900,
-    load_embeddings,
-    load_params_1900,
+    load_params,
+    load_embedding_1900,
     one_hots,
     validate_mLSTM1900_params,
 )
@@ -97,7 +96,7 @@ def evotuning_pairs(s: str) -> Tuple[np.ndarray, np.ndarray]:
     """
     seq_int = aa_seq_to_int(s[:-1])
     next_letters_int = aa_seq_to_int(s[1:])
-    embeddings = load_embeddings()
+    embeddings = load_embedding_1900()
     x = np.stack([embeddings[i] for i in seq_int])
     y = np.stack([one_hots[i] for i in next_letters_int])
     return x, y
@@ -204,7 +203,7 @@ def fit(
 
     # Load and check that params have correct keys and shapes
     if params is None:
-        params = (load_params_1900(), (), load_dense_1900(), ())
+        params = load_params()
 
     # Defensive programming checks
     if len(params) != len(model_layers):
@@ -276,9 +275,9 @@ def fit(
                     + f"holdout-loss={avg_loss(holdout_seqs, get_params(state))}, "
                 )
 
-                # dump current params in case run crashes or loss increases
-                # steps printed are 1-indexed i.e. starts at epoch 1 not 0.
-                dump_params(get_params(state), proj_name, (i + 1))
+            # dump current params in case run crashes or loss increases
+            # steps printed are 1-indexed i.e. starts at epoch 1 not 0.
+            dump_params(get_params(state), proj_name, (i + 1))
 
     return get_params(state)
 

--- a/jax_unirep/utils.py
+++ b/jax_unirep/utils.py
@@ -45,11 +45,6 @@ aa_to_int = {
 proposal_valid_letters = "ACDEFGHIKLMNPQRSTVWY"
 
 
-# weights_1900_dir = Path(
-#     pkg_resources.resource_filename(
-#         "jax_unirep", "weights/1900_weights/uniref50"
-#     )
-# )
 def get_weights_dir(folderpath: Optional[str] = None):
     """
     Fetch the paper weights per default, or from a specified folderpath
@@ -263,11 +258,6 @@ def load_params(folderpath: Optional[str] = None):
         load_dense_1900(folderpath=folderpath),
         (),
     )
-
-
-# def load_embeddings(path: str = None):
-#     """Load embeddings of amino acids for the uniref50 model."""
-#     return np.load(weights_1900_dir / "embed_matrix:0.npy")
 
 
 def l2_normalize(arr, axis, epsilon=1e-12):

--- a/jax_unirep/utils.py
+++ b/jax_unirep/utils.py
@@ -135,7 +135,7 @@ def aa_seq_to_int(s):
     return [24] + [aa_to_int[a] for a in s] + [25]
 
 
-def load_embedding_1900(folderpath: str = None):
+def load_embedding_1900(folderpath: Optional[str] = None):
     """Load pre-trained embedding weights for uniref50 model."""
     if folderpath:
         weights_1900_dir = Path(folderpath)
@@ -188,7 +188,7 @@ Sequence length: number of sequences information in the dictionary below.
     return onp.stack(seq_embeddings, axis=0)
 
 
-def load_dense_1900(folderpath: str = None) -> Tuple:
+def load_dense_1900(folderpath: Optional[str] = None) -> Tuple:
     """
     Load pre-trained dense layer weights from the UniRep paper.
 
@@ -209,7 +209,7 @@ def load_dense_1900(folderpath: str = None) -> Tuple:
     return w, b
 
 
-def load_params_1900(folderpath: str = None) -> Dict:
+def load_params_1900(folderpath: Optional[str] = None) -> Dict:
     """Load pre-trained mLSTM1900 weights from the UniRep paper."""
     if folderpath:
         print(folderpath)
@@ -264,7 +264,7 @@ def validate_mLSTM1900_params(params: Dict):
             )
 
 
-def load_params(folderpath: str = None):
+def load_params(folderpath: Optional[str] = None):
     return (
         load_params_1900(folderpath=folderpath),
         (),

--- a/jax_unirep/utils.py
+++ b/jax_unirep/utils.py
@@ -50,6 +50,18 @@ proposal_valid_letters = "ACDEFGHIKLMNPQRSTVWY"
 #         "jax_unirep", "weights/1900_weights/uniref50"
 #     )
 # )
+def get_weights_dir(folderpath: Optional[str] = None):
+    """
+    Fetch the paper weights per default, or from a specified folderpath
+    """
+    if folderpath:
+        return Path(folderpath)
+    else:
+        return Path(
+            pkg_resources.resource_filename(
+                "jax_unirep", "weights/1900_weights/uniref50"
+            )
+        )
 
 
 def dump_params(
@@ -137,14 +149,8 @@ def aa_seq_to_int(s):
 
 def load_embedding_1900(folderpath: Optional[str] = None):
     """Load pre-trained embedding weights for uniref50 model."""
-    if folderpath:
-        weights_1900_dir = Path(folderpath)
-    else:
-        weights_1900_dir = Path(
-            pkg_resources.resource_filename(
-                "jax_unirep", "weights/1900_weights/uniref50"
-            )
-        )
+    weights_1900_dir = get_weights_dir(folderpath=folderpath)
+
     return np.load(weights_1900_dir / "embed_matrix:0.npy")
 
 
@@ -195,15 +201,8 @@ def load_dense_1900(folderpath: Optional[str] = None) -> Tuple:
     The dense layer weights are used to predict next character
     from the output of the mLSTM1900.
     """
-    if folderpath:
-        weights_1900_dir = Path(folderpath)
-    else:
-        weights_1900_dir = Path(
-            pkg_resources.resource_filename(
-                "jax_unirep", "weights/1900_weights/uniref50"
-            )
-        )
-    # params = dict()
+    weights_1900_dir = get_weights_dir(folderpath=folderpath)
+
     w = np.load(weights_1900_dir / "fully_connected_weights:0.npy")
     b = np.load(weights_1900_dir / "fully_connected_biases:0.npy")
     return w, b
@@ -211,15 +210,8 @@ def load_dense_1900(folderpath: Optional[str] = None) -> Tuple:
 
 def load_params_1900(folderpath: Optional[str] = None) -> Dict:
     """Load pre-trained mLSTM1900 weights from the UniRep paper."""
-    if folderpath:
-        print(folderpath)
-        weights_1900_dir = Path(folderpath)
-    else:
-        weights_1900_dir = Path(
-            pkg_resources.resource_filename(
-                "jax_unirep", "weights/1900_weights/uniref50"
-            )
-        )
+    weights_1900_dir = get_weights_dir(folderpath=folderpath)
+
     params = dict()
     params["gh"] = np.load(weights_1900_dir / "rnn_mlstm_mlstm_gh:0.npy")
     params["gmh"] = np.load(weights_1900_dir / "rnn_mlstm_mlstm_gmh:0.npy")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from jax_unirep.utils import batch_sequences, l2_normalize, get_batch_len
+from jax_unirep.utils import batch_sequences, get_batch_len, l2_normalize
 
 
 def test_l2_normalize():


### PR DESCRIPTION
The passing of params in evotuning was handled inconsistently.
This PR changes this, such that `params` now always expects the full tuple
of weights: (mlstm1900, (), Dense, ()).

Weight dumping got adjusted accordingly, and there is a new convenience function
`load_params`, that by defaults loads all weights from the paper, and can also load previously dumped weights when supplied a folder path.
