### PR TITLE
[ENH] Speed up evotuning and improve evotuning ergonomics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ paper/cabios-template/fig01.eps
 default.profraw
 paper/cabios-template/speed-comparison.png
 paper/cabios-template/Untitled.ipynb
+*/temp/*
+temp/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,3 @@ repos:
     rev: 19.10b0
     hooks:
     -   id: black
--   repo: https://gitlab.com/pycqa/flake8
-    rev: ''  # pick a git hash / tag to point to
-    hooks:
-    -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
     rev: 19.10b0
     hooks:
     -   id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: ''  # pick a git hash / tag to point to
+    hooks:
+    -   id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@ In the changelog, @ElArkk and @ericmjl would like to acknowledge contributors wh
 <Please add your contribution to the top>
 
 - 20 April 2020: Code fixes for major bug with negative and NaN losses due to Softmax issue by @ivanjayapurna,
-- 20 April 2020: (Also by @ivanjayapurna) Overhauled evotuning.py with major changes including 
-    1. option to supply an out-domain holdout set and print params as training progresses, 
-    2. evotuning without Optuna by directly calling fit function, 
+- 20 April 2020: (Also by @ivanjayapurna) Overhauled evotuning.py with major changes including
+    1. option to supply an out-domain holdout set and print params as training progresses,
+    2. evotuning without Optuna by directly calling fit function,
     3. added avg_loss() function for calculation outputting of training and holdout set loss to a log file (number and length of batches are also calculated and printed to log file),
     4. introduction of "steps_per_print" to periodically calculate losses and dump parameters
-    5. Implemented adamW in JAX and switched optimizer to adamW, 
-    6. added option to change the number of folds in optuna KFolds, 
+    5. Implemented adamW in JAX and switched optimizer to adamW,
+    6. added option to change the number of folds in optuna KFolds,
     7. update evotuning-prototype.py example script
 - 30 March 2020: Code fixes for correctness and readability, and a parameter dumping function by @ivanjayapurna,
+- 28 June 2020: Improvements to evotuning ergonomics:
+    1. Adds a pre-commit configuration.
+    1. Adds an installation script that makes easy the installation of jax on GPU.
+    1. Provided backend specification of device (GPU/CPU).
+    1. Switched preparation of sequences as input-output pairs exclusively on CPU, for speed.
+    1. Added ergonomic UI features - progressbars! - that improve user experience.
+    1. Added docs on recommended batch size and its relationship to GPU RAM consumption.
+    1. Switched from exact calculation of train/holdout loss to estimated calculation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ In the changelog, @ElArkk and @ericmjl would like to acknowledge contributors wh
     1. option to supply an out-domain holdout set and print params as training progresses,
     2. evotuning without Optuna by directly calling fit function,
     3. added avg_loss() function for calculation outputting of training and holdout set loss to a log file (number and length of batches are also calculated and printed to log file),
-    4. introduction of "steps_per_print" to periodically calculate losses and dump parameters
+    4. introduction of "epochs_per_print" to periodically calculate losses and dump parameters
     5. Implemented adamW in JAX and switched optimizer to adamW,
     6. added option to change the number of folds in optuna KFolds,
     7. update evotuning-prototype.py example script

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ style:
 	@printf "\033[1;34mPylint passes!\033[0m\n\n"
 
 test:  # Test code using pytest.
-	pytest -v . --cov=./jax_unirep
+	pytest -v . --cov=./jax_unirep --cov-report term-missing
 
 paper:
 	cd paper && bash build.sh

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ The `fit` function has further customization options,
 such as different batching strategies.
 Please see the function docstring for more information.
 
+NOTE: The `fit` function will always default to using a
+GPU `backend` if available for the forward and backward passes
+during training of the LSTM.
+However, for the calulation of the average loss
+on the dataset after every epoch, you can decide
+if the CPU or GPU `backend` should be used (default is CPU).
+
 You can find an example usages of both `evotune` and `fit` [here][examples].
 
 If you want to pass a set of mLSTM and dense weights

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - pytest=5.3.4
   - pandoc=2.9.1.1
   - pytest-cov=2.8.1
+  - pre-commit
   - ipykernel=5.1.4
   - optuna=1.1.0
   - scikit-learn=0.22.1

--- a/examples/evotuning.py
+++ b/examples/evotuning.py
@@ -26,7 +26,7 @@ study, evotuned_params = evotune(
     n_splits=2,
     n_epochs_config=n_epochs_config,
     learning_rate_config=lr_config,
-    steps_per_print=1,
+    epochs_per_print=1,
 )
 
 dump_params(evotuned_params, PROJECT_NAME)
@@ -47,7 +47,7 @@ evotuned_params = fit(
     step_size=LEARN_RATE,
     holdout_seqs=holdout_sequences,
     proj_name=PROJECT_NAME,
-    steps_per_print=1,
+    epochs_per_print=1,
 )
 
 dump_params(evotuned_params, PROJECT_NAME)

--- a/examples/fitting.py
+++ b/examples/fitting.py
@@ -2,9 +2,9 @@
 import logging
 from random import shuffle
 
+from Bio import SeqIO
 from pyprojroot import here
 
-from Bio import SeqIO
 from jax_unirep import fit
 from jax_unirep.utils import dump_params
 

--- a/examples/fitting.py
+++ b/examples/fitting.py
@@ -38,6 +38,7 @@ evotuned_params = fit(
     batch_method="random",
     proj_name=PROJECT_NAME,
     epochs_per_print=None,
+    backend="gpu",  # default is "cpu"
 )
 
 dump_params(evotuned_params, PROJECT_NAME)

--- a/examples/fitting.py
+++ b/examples/fitting.py
@@ -37,7 +37,7 @@ evotuned_params = fit(
     holdout_seqs=holdout_sequences,
     batch_method="random",
     proj_name=PROJECT_NAME,
-    steps_per_print=None,
+    epochs_per_print=None,
 )
 
 dump_params(evotuned_params, PROJECT_NAME)

--- a/install_jaxgpu.sh
+++ b/install_jaxgpu.sh
@@ -1,0 +1,10 @@
+conda env update -f environment.yml
+
+PYTHON_VERSION=cp37
+CUDA_VERSION=cuda101
+PLATFORM=manylinux2010_x86_64
+BASE_URL='https://storage.googleapis.com/jax-releases'
+pip install --upgrade $BASE_URL/$CUDA_VERSION/jaxlib-0.1.50-$PYTHON_VERSION-none-$PLATFORM.whl
+pip install --upgrade jax
+
+jupyter labextension install @jupyter-widgets/jupyterlab-manager

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -2,29 +2,26 @@
 import logging
 from functools import partial
 from random import choice
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import numpy as onp
 import optuna
-from jax import grad, jit, lax
+from jax import grad, jit
 from jax import numpy as np
-from jax import random, vmap
-from jax.experimental.optimizers import adam
+from jax import vmap
 from jax.experimental.stax import Dense, Softmax, serial
-from sklearn.model_selection import KFold, train_test_split
+from sklearn.model_selection import KFold
 from tqdm.autonotebook import tqdm
 
 from jax_unirep.losses import _neg_cross_entropy_loss
 
-from .layers import mLSTM1900, mLSTM1900_AvgHidden, mLSTM1900_HiddenStates
+from .layers import mLSTM1900, mLSTM1900_HiddenStates
 from .optimizers import adamW
-from .params import add_dense_params
 from .utils import (
     aa_seq_to_int,
     batch_sequences,
     dump_params,
     get_batching_func,
-    get_embeddings,
     load_embedding_1900,
     load_params,
     one_hots,
@@ -65,8 +62,14 @@ def avg_loss(
     :param xs: List of NumPy arrays
     :param ys: List of NumPy arrays
     :param params: parameters (i.e. from training)
-    :param backend: Whether to use GPU ('gpu') or CPU ('cpu') to perform calculation. Defaults to 'cpu'.
-    :param batch_size: Size of batch when calculating average loss over train or holdout set. Controlling this parameter helps with memory allocation issues - reduce this parameter's size to reduce the amount of RAM allocation needed to calculate loss.
+    :param backend: Whether to use GPU ('gpu') or CPU ('cpu')
+        to perform calculation.
+        Defaults to 'cpu'.
+    :param batch_size: Size of batch when calculating average loss
+        over train or holdout set.
+        Controlling this parameter helps with memory allocation issues -
+        reduce this parameter's size to reduce the amount of RAM allocation
+        needed to calculate loss.
     """
     logging.debug("Calculating average loss.")
     sum_loss = 0
@@ -199,7 +202,7 @@ def fit(
     holdout_seqs: Optional[Set[str]] = set(),
     proj_name: Optional[str] = "temp",
     steps_per_print: Optional[int] = 200,
-    backend="gpu",
+    backend="cpu",
 ) -> Dict:
     """
     Return mLSTM weights fitted to predict the next letter in each AA sequence.

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -204,7 +204,7 @@ def fit(
     batch_method: Optional[str] = "length",
     batch_size: Optional[int] = 25,
     step_size: float = 0.0001,
-    holdout_seqs: Optional[Set[str]] = set(),
+    holdout_seqs: Optional[Set[str]] = None,
     proj_name: Optional[str] = "temp",
     epochs_per_print: Optional[int] = 200,
     backend="cpu",

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -29,7 +29,6 @@ from .utils import (
     validate_mLSTM1900_params,
 )
 
-
 # setup logger
 logger = logging.getLogger("evotuning")
 logger.setLevel(logging.INFO)

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -388,8 +388,8 @@ def fit(
 
             if holdout_seqs is not None:
                 # calculate and print loss for out-domain holdout set
-                l = choice(holdout_seq_lens)
-                x, y = holdout_len_batching_funcs[l]()
+                hl = choice(holdout_seq_lens)
+                x, y = holdout_len_batching_funcs[hl]()
                 loss = avg_loss([x], [y], params, backend=backend)
                 logger.info(
                     f"Epoch {current_epoch - 1}: "

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -202,6 +202,7 @@ def fit(
     holdout_seqs: Optional[Set[str]] = set(),
     proj_name: Optional[str] = "temp",
     steps_per_print: Optional[int] = 200,
+    backend="gpu",
 ) -> Dict:
     """
     Return mLSTM weights fitted to predict the next letter in each AA sequence.
@@ -270,6 +271,8 @@ def fit(
     :param proj_name: The directory path for weights to be output to.
     :param steps_per_print: Number of steps per printing and dumping
         of weights.
+    :param backend: Whether or not to use the GPU. Defaults to "cpu",
+        but can be set to "gpu" if desired.
     """
 
     @jit
@@ -364,7 +367,7 @@ def fit(
         if i % epoch_len == 0:
             params = get_params(state)
             x, y = len_batching_funcs[l]()
-            loss = avg_loss([x], [y], params, backend="gpu")
+            loss = avg_loss([x], [y], params, backend=backend)
 
         if steps_per_print:
             if (i + 1) % (steps_per_print * epoch_len) == 0:
@@ -379,7 +382,7 @@ def fit(
                     # calculate and print loss for out-domain holdout set
                     l = choice(holdout_seq_lens)
                     x, y = holdout_len_batching_funcs[l]()
-                    loss = avg_loss([x], [y], params, backend="gpu")
+                    loss = avg_loss([x], [y], params, backend=backend)
                     logger.info(
                         f"Epoch {int(i / epoch_len) + 1}: "
                         + f"Estimaged average holdout-set loss: {loss}"

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -128,9 +128,7 @@ def evotuning_pairs(s: str) -> Tuple[np.ndarray, np.ndarray]:
     return x, y
 
 
-def input_output_pairs(
-    sequences: List[str], parallel: bool = False
-) -> Tuple[np.ndarray, np.ndarray]:
+def input_output_pairs(sequences: List[str],) -> Tuple[np.ndarray, np.ndarray]:
     """
     Generate input-output tensor pairs for evo-tuning.
 
@@ -139,7 +137,6 @@ def input_output_pairs(
 
     :param sequences: A list of sequences
         to generate input-output tensor pairs.
-    :param parallel: Whether to use all cores on a system
     :returns: Two NumPy arrays,
         the first corresponding to the input to evotuning
         with shape (n_sequences, n_letters+1, 10),

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -201,7 +201,7 @@ def fit(
     params: Dict,
     sequences: Set[str],
     n_epochs: int,
-    batch_method: Optional[str] = "length",
+    batch_method: Optional[str] = "random",
     batch_size: Optional[int] = 25,
     step_size: float = 0.0001,
     holdout_seqs: Optional[Set[str]] = None,

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -324,7 +324,8 @@ def fit(
         )
 
     len_batching_funcs = {
-        sl: get_batching_func(x, y, batch_size) for (sl, x, y) in zip(seq_lens, xs, ys)
+        sl: get_batching_func(x, y, batch_size)
+        for (sl, x, y) in zip(seq_lens, xs, ys)
     }
     if holdout_seqs:
         holdout_len_batching_funcs = {
@@ -387,7 +388,9 @@ def fit(
 
                 # dump current params in case run crashes or loss increases
                 # steps printed are 1-indexed i.e. starts at epoch 1 not 0.
-                dump_params(get_params(state), proj_name, (int(i / epoch_len) + 1))
+                dump_params(
+                    get_params(state), proj_name, (int(i / epoch_len) + 1)
+                )
 
     return get_params(state)
 
@@ -448,7 +451,9 @@ def objective(
 
     n_epochs = trial.suggest_discrete_uniform(**n_epochs_kwargs)
     learning_rate = trial.suggest_loguniform(**learning_rate_kwargs)
-    logger.info(f"Trying out {n_epochs} epochs with learning rate {learning_rate}.")
+    logger.info(
+        f"Trying out {n_epochs} epochs with learning rate {learning_rate}."
+    )
 
     kf = KFold(n_splits=n_splits, shuffle=True)
     sequences = onp.array(sequences)
@@ -462,7 +467,10 @@ def objective(
         )
 
         evotuned_params = fit(
-            params, train_sequences, n_epochs=int(n_epochs), step_size=learning_rate,
+            params,
+            train_sequences,
+            n_epochs=int(n_epochs),
+            step_size=learning_rate,
         )
 
         xs, ys, _ = length_batch_input_outputs(sequences)
@@ -566,7 +574,9 @@ def evotune(
     num_epochs = int(study.best_params["n_epochs"])
     learning_rate = float(study.best_params["learning_rate"])
 
-    logger.info(f"Optuna done, starting tuning with learning rate={learning_rate}, ")
+    logger.info(
+        f"Optuna done, starting tuning with learning rate={learning_rate}, "
+    )
 
     evotuned_params = fit(
         params=params,

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -206,7 +206,7 @@ def fit(
     step_size: float = 0.0001,
     holdout_seqs: Optional[Set[str]] = None,
     proj_name: Optional[str] = "temp",
-    epochs_per_print: Optional[int] = 200,
+    epochs_per_print: Optional[int] = 1,
     backend="cpu",
 ) -> Dict:
     """

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -262,7 +262,9 @@ def fit(
     :param n: The number of iterations to evotune on.
     :param batch_method: One of "length" or "random".
     :param batch_size: If random batching is used,
-        number of sequences per batch. As a rule of thumb, batch size of 50 consumes about 5GB of RAM.
+        number of sequences per batch.
+        As a rule of thumb, batch size of 50 consumes
+        about 5GB of GPU RAM.
     :param step_size: The learning rate.
     :param holdout_seqs: Holdout set, an optional input.
     :param proj_name: The directory path for weights to be output to.

--- a/jax_unirep/params.py
+++ b/jax_unirep/params.py
@@ -16,7 +16,7 @@ def add_dense_params(
 
 
 def add_mLSTM1900_params(
-    params: Dict, name: str, input_dim: int, output_dim: int
+    params: Dict, name: str, input_dim: int = 10, output_dim: int = 1900
 ) -> Dict:
     params[name] = dict()
     params[name]["wmx"] = normal(split(key)[0], (input_dim, output_dim))

--- a/jax_unirep/utils.py
+++ b/jax_unirep/utils.py
@@ -1,10 +1,10 @@
 """jax-unirep utils."""
 import os
 from collections import Counter
+from functools import lru_cache
 from pathlib import Path
 from random import choice, sample
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
-from functools import lru_cache
 
 import jax.numpy as np
 import numpy as onp

--- a/jax_unirep/utils.py
+++ b/jax_unirep/utils.py
@@ -13,37 +13,37 @@ from tqdm.autonotebook import tqdm
 
 from .errors import SequenceLengthsError
 
-aa_to_int = dict()
-aa_to_int["-"] = 0
-aa_to_int["M"] = 1
-aa_to_int["R"] = 2
-aa_to_int["H"] = 3
-aa_to_int["K"] = 4
-aa_to_int["D"] = 5
-aa_to_int["E"] = 6
-aa_to_int["S"] = 7
-aa_to_int["T"] = 8
-aa_to_int["N"] = 9
-aa_to_int["Q"] = 10
-aa_to_int["C"] = 11
-aa_to_int["U"] = 12
-aa_to_int["G"] = 13
-aa_to_int["P"] = 14
-aa_to_int["A"] = 15
-aa_to_int["V"] = 16
-aa_to_int["I"] = 17
-aa_to_int["F"] = 18
-aa_to_int["Y"] = 19
-aa_to_int["W"] = 20
-aa_to_int["L"] = 21
-aa_to_int["O"] = 22  # Pyrrolysine
-aa_to_int["X"] = 23  # Unknown
-aa_to_int["Z"] = 23  # Glutamic acid or GLutamine
-aa_to_int["B"] = 23  # Asparagine or aspartic acid
-aa_to_int["J"] = 23  # Leucine or isoleucine
-aa_to_int["start"] = 24
-aa_to_int["stop"] = 25
-
+aa_to_int = {
+    "-": 0,
+    "M": 1,
+    "R": 2,
+    "H": 3,
+    "K": 4,
+    "D": 5,
+    "E": 6,
+    "S": 7,
+    "T": 8,
+    "N": 9,
+    "Q": 10,
+    "C": 11,
+    "U": 12,
+    "G": 13,
+    "P": 14,
+    "A": 15,
+    "V": 16,
+    "I": 17,
+    "F": 18,
+    "Y": 19,
+    "W": 20,
+    "L": 21,
+    "O": 22,  # Pyrrolysine
+    "X": 23,  # Unknown
+    "Z": 23,  # Glutamic acid or GLutamine
+    "B": 23,  # Asparagine or aspartic acid
+    "J": 23,  # Leucine or isoleucine
+    "start": 24,
+    "stop": 25,
+}
 proposal_valid_letters = "ACDEFGHIKLMNPQRSTVWY"
 
 

--- a/jax_unirep/utils.py
+++ b/jax_unirep/utils.py
@@ -315,11 +315,14 @@ def batch_sequences(seqs: Iterable[str]) -> List[List]:
 def right_pad(seqs: Iterable[str], max_len: int):
     """Pad all seqs in a list to longest length on the right with "-"."""
     return [
-        seq.ljust(max_len, "-") for seq in tqdm(seqs, desc="right-padding sequences")
+        seq.ljust(max_len, "-")
+        for seq in tqdm(seqs, desc="right-padding sequences")
     ]
 
 
-def get_batching_func(xs: np.ndarray, ys: np.ndarray, batch_size: int = 25) -> Callable:
+def get_batching_func(
+    xs: np.ndarray, ys: np.ndarray, batch_size: int = 25
+) -> Callable:
     """
     Create a function which returns batches of sequences
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+# Example configuration for Black.
+
+# NOTE: you have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python.  Multiline strings are treated as
+# verbose regular expressions by Black.  Use [ ] to denote a significant space
+# character.
+
+[tool.black]
+line-length = 79
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+
+  # The following are specific to Black, you probably don't want those.
+  | blib2to3
+  | tests/data
+  | profiling
+)/
+'''
+
+
+# Build system information below.
+# NOTE: You don't need this in your own Black configuration.
+
+[build-system]
+requires = ["setuptools>=41.0", "setuptools-scm", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_evotuning.py
+++ b/tests/test_evotuning.py
@@ -100,17 +100,28 @@ def test_predict(params):
     assert res.max() <= 1
 
 
-def test_fit(params):
+@pytest.mark.parametrize("holdout_seqs", (["ASDV", None]))
+def test_fit(params, holdout_seqs):
     """
     Execution test for ``jax_unirep.evotuning.fit``.
     """
     sequences = ["ASDFGHJKL", "ASDYGHTKW", "HSKS", "HSGL", "ER"]
 
     length_fitted_params = fit(
-        params, sequences, n_epochs=1, batch_method="length", batch_size=2
+        params,
+        sequences,
+        n_epochs=1,
+        batch_method="length",
+        batch_size=2,
+        holdout_seqs=holdout_seqs,
     )
     random_fitted_params = fit(
-        params, sequences, n_epochs=1, batch_method="random", batch_size=2
+        params,
+        sequences,
+        n_epochs=1,
+        batch_method="random",
+        batch_size=2,
+        holdout_seqs=holdout_seqs,
     )
 
     validate_mLSTM1900_params(length_fitted_params[0])

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -19,7 +19,5 @@ def test_add_mLSTM1900_params():
     I thus defaulted to just using an execution test.
     """
     params = dict()
-    params = add_mLSTM1900_params(
-        params, name="mLSTM1900", input_dim=1900, output_dim=40
-    )
+    params = add_mLSTM1900_params(params, name="mLSTM1900",)
     validate_mLSTM1900_params(params["mLSTM1900"])

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,5 +1,5 @@
 from jax_unirep.params import add_dense_params, add_mLSTM1900_params
-
+from jax_unirep.utils import validate_mLSTM1900_params
 
 def test_add_dense_params():
     """Unit test for add_dense_params."""

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -21,3 +21,4 @@ def test_add_mLSTM1900_params():
     params = add_mLSTM1900_params(
         params, name="mLSTM1900", input_dim=1900, output_dim=40
     )
+    validate_mLSTM1900_params(params)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -7,8 +7,8 @@ def test_add_dense_params():
     params = add_dense_params(
         params, name="param1", input_dim=40, output_dim=20
     )
-    assert params["w"].shape == (40, 20)
-    assert params["b"].shape == (20,)
+    assert params["param1"]["w"].shape == (40, 20)
+    assert params["param1"]["b"].shape == (20,)
 
 
 def test_add_mLSTM1900_params():

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -2,10 +2,22 @@ from jax_unirep.params import add_dense_params, add_mLSTM1900_params
 
 
 def test_add_dense_params():
-    """Placeholder for actual test."""
-    pass
+    """Unit test for add_dense_params."""
+    params = dict()
+    params = add_dense_params(
+        params, name="param1", input_dim=40, output_dim=20
+    )
+    assert params["w"].shape == (40, 20)
+    assert params["b"].shape == (20,)
 
 
 def test_add_mLSTM1900_params():
-    """Placeholder for actual test."""
-    pass
+    """Execution test for add_mLSTM1900_params.
+
+    Forgive me, I was being lazy when doing this test,
+    I thus defaulted to just using an execution test.
+    """
+    params = dict()
+    params = add_mLSTM1900_params(
+        params, name="mLSTM1900", input_dim=1900, output_dim=40
+    )

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,11 @@
+from jax_unirep.params import add_dense_params, add_mLSTM1900_params
+
+
+def test_add_dense_params():
+    """Placeholder for actual test."""
+    pass
+
+
+def test_add_mLSTM1900_params():
+    """Placeholder for actual test."""
+    pass

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,6 +1,7 @@
 from jax_unirep.params import add_dense_params, add_mLSTM1900_params
 from jax_unirep.utils import validate_mLSTM1900_params
 
+
 def test_add_dense_params():
     """Unit test for add_dense_params."""
     params = dict()
@@ -21,4 +22,4 @@ def test_add_mLSTM1900_params():
     params = add_mLSTM1900_params(
         params, name="mLSTM1900", input_dim=1900, output_dim=40
     )
-    validate_mLSTM1900_params(params)
+    validate_mLSTM1900_params(params["mLSTM1900"])


### PR DESCRIPTION
## PR Description

Before you read on, please ignore the branch name. I thought originally that I could use numba to speed up things, but it turned out that once again, with some careful profiling, I found we didn't have to.

This PR does a few things:

1. Adds a pre-commit configuration.
2. Adds an installation script that makes easy the installation of jax on GPU.
3. Provided backend specification of device (GPU/CPU).
4. Switched preparation of sequences as input-output pairs exclusively on CPU, for speed.
5. Added ergonomic UI features - progressbars! - that improve user experience.
6. Added docs on recommended batch size and its relationship to GPU RAM consumption.
7. Switched from exact calculation of train/holdout loss to estimated calculation.

In any case, this PR closes #56.

## Checklist

### General
1. [x] I have made the PR off a new branch from my fork 
   (`<your_username>`:`<feature-branch_name>`), *not* 
   `<your_username>`:`master`.
2. [x] I have added my changes to the `CHANGELOG.md` file at the top.
3. [x] I have made any necessary changes to the documentation in the `README`.

### Code checks
1. [x] If there are new features implemented, add suitable tests
   in the `tests` directory.
2. [ ] If any new dependencies are introduced through the new features,
   add the packages, pinned to a version, to `environment.yml`.
3. [x] Run `make test` in a console in the top level directory
   to make sure all the tests pass.
4. [x] Run `make format` in a console in the top level directory
   to make the code comply with the formatting standards.
