### PR TITLE
Pin jax version to < 0.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - conda>=4.8.2
   - coverage>=5.0.3
   - hypothesis>=5.2.0
-  - jax>=0.1.57
+  - jax>=0.1.57,<0.2.0
   - jaxlib>=0.1.37
   - jupyter
   - jupyterlab

--- a/install_jaxgpu.sh
+++ b/install_jaxgpu.sh
@@ -5,6 +5,6 @@ CUDA_VERSION=cuda101
 PLATFORM=manylinux2010_x86_64
 BASE_URL='https://storage.googleapis.com/jax-releases'
 pip install --upgrade $BASE_URL/$CUDA_VERSION/jaxlib-0.1.50-$PYTHON_VERSION-none-$PLATFORM.whl
-pip install --upgrade jax
+pip install --upgrade 'jax<0.2.0'
 
 jupyter labextension install @jupyter-widgets/jupyterlab-manager

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "jax_unirep": ["weights/1900_weights/uniref50/*.npy"],
     },
     install_requires=[
-        "jax",
+        "jax<0.2.0",
         "jaxlib",
         "multipledispatch",
         "numpy",


### PR DESCRIPTION
Jax 0.2.0 breaks this:

```
from jax_unirep import get_reps
h_avg, h_final, c_final = get_reps(["ASDF", "YJKAL", "QQLAMEHALQP"])
```

This PR pins Jax to the latest v0.1.x and fixes #77 