### PR TITLE
Add NaN test for sigmoid and grad of sigmoid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ temp/*
 *.out
 *.bbl
 *.blg
+scratch/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 In the changelog, @ElArkk and @ericmjl would like to acknowledge contributors who have helped us with anything on the project, big or small.
 
-<Please add your contribution to the top>
+<!-- Please add your contribution to the top -->
+
+- 23 December 2020: Fixed bug with NaN values in grad (issue #94), by @ericmjl
+    1. h/t @r-karimi for discovering the bug.
 - 14 December 2020: Evotune log format bugfix by @ericmjl and @ElArkk
     1. Reported by @jmahenriques in issue #93
 - 2 December 2020: Implementation of embedding layer by @ElArkk
@@ -21,7 +24,6 @@ In the changelog, @ElArkk and @ericmjl would like to acknowledge contributors wh
     1. option to supply an out-domain holdout set and print params as training progresses,
     2. evotuning without Optuna by directly calling fit function,
     3. added avg_loss() function for calculation outputting of training and holdout set loss to a log file (number and length of batches are also calculated and printed to log file),
-
     4. introduction of "epochs_per_print" to periodically calculate losses and dump parameters
     5. Implemented adamW in JAX and switched optimizer to adamW,
     6. added option to change the number of folds in optuna KFolds,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ In the changelog, @ElArkk and @ericmjl would like to acknowledge contributors wh
 
 <!-- Please add your contribution to the top -->
 
+- 23 December 2020: Snuck in a fix for incorrect logger info, by @ericmjl.
 - 23 December 2020: Fixed bug with NaN values in grad (issue #94), by @ericmjl
     1. h/t @r-karimi for discovering the bug.
 - 14 December 2020: Evotune log format bugfix by @ericmjl and @ElArkk

--- a/jax_unirep/activations.py
+++ b/jax_unirep/activations.py
@@ -2,14 +2,28 @@ import jax.numpy as np
 
 
 def sigmoid(x, version="tanh"):
-    if version not in ["tanh", "exp"]:
-        raise ValueError("version must be one of ['tanh' or 'exp']")
+    """Sigmoid activation function.
 
+    Two versions are provided: "tanh" and "exp".
+    "exp" is used in the re-implementation.
+    """
     sigmoids = {
         "tanh": lambda x: 0.5 * np.tanh(x) + 0.5,
-        "exp": lambda x: 1 / (1 + np.exp(-x)),
+        "exp": lambda x: safe_sigmoid_exp(x),
     }
     return sigmoids[version](x)
+
+
+def safe_sigmoid_exp(x, clip_value=-88):
+    """
+    Safe version of exp version of sigmoid.
+
+    Based on the test "test_sigmoid", we found that a value of -89.0
+    gives us NaN values when calculating the gradient of sigmoid.
+    As such, we clip -x to a minimum value of -88.0.
+    """
+    x = np.clip(x, a_min=-88)
+    return 1 / (1 + np.exp(-x))
 
 
 def relu(x, alpha=0.1):

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -316,9 +316,10 @@ def fit(
             f"and min batch length {min(batch_lens)}."
         )
     elif batch_method == "random":
+        # Both training_seq_lens
         logger.info(
             f"Random batching done: "
-            f"All sequences padded to max sequence length of {max(seq_lens)}"
+            f"All sequences padded to max sequence length of {max(training_seq_lens)}"
         )
 
     init, update, get_params = adamW(step_size=step_size)

--- a/jax_unirep/evotuning.py
+++ b/jax_unirep/evotuning.py
@@ -318,7 +318,7 @@ def fit(
     elif batch_method == "random":
         logger.info(
             f"Random batching done: "
-            f"All sequences padded to max sequence length of {max(batch_lens)}"
+            f"All sequences padded to max sequence length of {max(seq_lens)}"
         )
 
     init, update, get_params = adamW(step_size=step_size)

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -1,0 +1,22 @@
+"""Tests for activation functions.
+
+In particular, we are looking for tests that cause NaN errors in grads.
+"""
+from hypothesis import strategies as st, given, settings
+from jax_unirep.activations import sigmoid
+import pytest
+import jax.numpy as np
+from jax import grad
+
+
+@pytest.mark.parametrize("version", ["tanh", "exp"])
+@given(x=st.floats(allow_nan=False, allow_infinity=False))
+@settings(deadline=None)
+def test_sigmoid(x, version):
+    """Check for null gradient issues."""
+    result = sigmoid(x, version=version)
+    assert not np.isnan(result)
+
+    dsigmoid = grad(sigmoid)
+    dresult = dsigmoid(x, version=version)
+    assert not np.isnan(dresult)


### PR DESCRIPTION
## PR Description

This PR closes #94. In there, @r-karimi uncovered a bug with NaN values showing up in the grad function. Upon deeper digging, I found out that NaN values could show up in the sigmoid function when large magnitude negative values are passed in. I thus modified the implementation of the sigmoid function such that we clip the value passed into sigmoid such that it is at minimum -88.0. 

## Checklist

### General

1. [x] I have made the PR off a new branch from my fork 
   (`<your_username>`:`<feature-branch_name>`), *not* 
   `<your_username>`:`master`.
2. [ ] I have added my changes to the `CHANGELOG.md` file at the top.
3. [x] I have made any necessary changes to the documentation in the `README`.

### Code checks
1. [x] If there are new features implemented, add suitable tests
   in the `tests` directory.
2. [-] If any new dependencies are introduced through the new features,
   add the packages, pinned to a version, to `environment.yml`.
3. [x] Run `make test` in a console in the top level directory
   to make sure all the tests pass.
4. [x] Run `make format` in a console in the top level directory
   to make the code comply with the formatting standards.
