### PR TITLE
Add autorelease github action

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,7 @@
+# Bump2version configuration file
+[bumpversion]
+current_version = 2.0.1
+commit = True
+tag = True
+
+[bumpversion:file:jax_unirep/version.py]

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,47 @@
+# Publishes a new release of the package
+# whenever there is a new tagged commit to the master branch.
+#
+# The typical workflow for cutting a new release requires executing the following commands:
+# - git checkout master
+# - bumpversion [major/minor/patch] (pick one)
+# - python setup.py sdist bdist_wheel
+# - twine upload dist/*
+# - git push && git push --tags
+#
+# This action thus eliminates the latter two steps by automating them away,
+# as they are routine and always the same.
+# The `.bumpversion.cfg` file automatically configures git to tag the commit with a release tag
+# and put in a commit message.
+# As such, the new workflow becomes:
+# - git checkout master
+# - bumpversion [major/minor/patch] (pick one)
+# - git push && git push --tags
+# i.e. we save two commands that need to be remembered.
+name: Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run setup script
+        run: |
+          python setup.py bdist_wheel sdist
+
+      - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true
+          # skip_existing: true  # leaving this in just in case.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,7 +17,7 @@
 # - bumpversion [major/minor/patch] (pick one)
 # - git push && git push --tags
 # i.e. we save two commands that need to be remembered.
-name: Publish
+name: Publish on PyPI
 
 on:
   push:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,8 @@
 # - python setup.py sdist bdist_wheel
 # - twine upload dist/*
 # - git push && git push --tags
+# - rm -rf dist
+# - rm -rf build
 #
 # This action thus eliminates the latter two steps by automating them away,
 # as they are routine and always the same.


### PR DESCRIPTION
## PR Description

This PR adds in an 'autorelease' github action. It still requires that we use bumpversion to tag commits, but now we can skip two shell commands instead. Laziness FTW :smile:.

## Checklist

### General
1. [x] I have made the PR off a new branch from my fork 
   (`<your_username>`:`<feature-branch_name>`), *not* 
   `<your_username>`:`master`.
~2. [ ] I have added my changes to the `CHANGELOG.md` file at the top.~
~3. [ ] I have made any necessary changes to the documentation in the `README`.~

### Code checks
~1. [ ] If there are new features implemented, add suitable tests
   in the `tests` directory.~
2. [x] If any new dependencies are introduced through the new features,
   add the packages, pinned to a version, to `environment.yml`.
~3. [ ] Run `make test` in a console in the top level directory
   to make sure all the tests pass.~
~4. [ ] Run `make format` in a console in the top level directory
   to make the code comply with the formatting standards.~
