### PR TITLE
Release version restriction for jax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "jax_unirep": ["weights/1900_weights/uniref50/*.pkl"],
     },
     install_requires=[
-        "jax<0.2.0",
+        "jax",
         "jaxlib",
         "multipledispatch",
         "numpy",


### PR DESCRIPTION
This was causing issues in installation from PyPI.