### PR TITLE
fix: replace jax.experimental with jax.example_libraries to fix import deprecation in latest jax release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ In the changelog, @ElArkk and @ericmjl would like to acknowledge contributors wh
 
 <!-- Please add your contribution to the top -->
 
+- 12 August 2022: Fixed jax dependency imports, by @aaroncsolomon
 - 23 December 2020: Snuck in a fix for incorrect logger info, by @ericmjl.
 - 23 December 2020: Fixed bug with NaN values in grad (issue #94), by @ericmjl
     1. h/t @r-karimi for discovering the bug.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ is licensed under the terms of [GPL v3][gpl3].
 [evotunefunc]: https://github.com/ElArkk/jax-unirep/blob/master/jax_unirep/evotuning.py#L421
 [fitfunc]: https://github.com/ElArkk/jax-unirep/blob/master/jax_unirep/evotuning.py#L163
 [examples]: https://github.com/ElArkk/jax-unirep/blob/master/examples
-[stax]: https://jax.readthedocs.io/en/latest/jax.experimental.stax.html
+[stax]: https://jax.readthedocs.io/en/latest/jax.example_libraries.stax.html
 [staxex]: https://github.com/google/jax/tree/master/examples
 [docs]: https://elarkk.github.io/jax-unirep/
 [cont]: https://elarkk.github.io/jax-unirep/contributing/

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -98,14 +98,14 @@ with the top model reps.
 You're in luck!
 
 We implemented the mLSTM layers in such a way that
-they are compatible with `jax.experimental.stax`.
+they are compatible with `jax.example_libraries.stax`.
 This means that they can easily be plugged into
 a `stax.serial` model, e.g. to train both the mLSTM
 and a top-model at once:
 
 ```python
-from jax.experimental import stax
-from jax.experimental.stax import Dense, Relu, serial
+from jax.example_libraries import stax
+from jax.example_libraries.stax import Dense, Relu, serial
 
 from jax_unirep.layers import AAEmbedding, mLSTM, mLSTMAvgHidden
 
@@ -123,7 +123,7 @@ init_fun, apply_fun = serial(
 Have a look at the [documentation][stax] and [examples][staxex]
 for more information about how to implement a model in `jax`.
 
-[stax]: https://jax.readthedocs.io/en/latest/jax.experimental.stax.html
+[stax]: https://jax.readthedocs.io/en/latest/jax.example_libraries.stax.html
 [staxex]: https://github.com/google/jax/tree/master/examples
 
 ## Sampling new protein sequences

--- a/docs/fitting.ipynb
+++ b/docs/fitting.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "from jax.random import PRNGKey\n",
-    "from jax.experimental.stax import Dense, Softmax, serial\n",
+    "from jax.example_libraries.stax import Dense, Softmax, serial\n",
     "\n",
     "from jax_unirep import fit\n",
     "from jax_unirep.evotuning_models import mlstm64\n",

--- a/examples/draft_cli.py
+++ b/examples/draft_cli.py
@@ -69,7 +69,7 @@ def main(
     logger.setLevel(logging.DEBUG)
     logger.info(f"There are {len(sequences)} sequences.")
 
-    LEARN_RATE = 10 ** learning_rate_power
+    LEARN_RATE = 10**learning_rate_power
     PROJECT_NAME = "temp"
 
     evotuned_params = fit(

--- a/jax_unirep/evotuning_models.py
+++ b/jax_unirep/evotuning_models.py
@@ -21,7 +21,7 @@ tuned_params = fit(
 )
 ```
 """
-from jax.experimental.stax import Dense, Softmax, serial
+from jax.example_libraries.stax import Dense, Softmax, serial
 
 from .layers import AAEmbedding, mLSTM, mLSTMHiddenStates
 

--- a/jax_unirep/optimizers.py
+++ b/jax_unirep/optimizers.py
@@ -1,5 +1,5 @@
 import jax.numpy as np
-from jax.experimental.optimizers import make_schedule, optimizer
+from jax.example_libraries.optimizers import make_schedule, optimizer
 
 
 @optimizer

--- a/jax_unirep/optimizers.py
+++ b/jax_unirep/optimizers.py
@@ -33,7 +33,7 @@ def adamW(step_size, b1=0.9, b2=0.999, eps=1e-8, w=0.01):
     def update(i, g, state):
         x, m, v = state
         m = (1 - b1) * g + b1 * m  # First  moment estimate.
-        v = (1 - b2) * (g ** 2) + b2 * v  # Second moment estimate.
+        v = (1 - b2) * (g**2) + b2 * v  # Second moment estimate.
         mhat = m / (1 - b1 ** (i + 1))  # Bias correction.
         vhat = v / (1 - b2 ** (i + 1))
         x = x - step_size(i) * (mhat / (np.sqrt(vhat) + eps) + w * x)

--- a/tests/test_evotuning.py
+++ b/tests/test_evotuning.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import pytest
-from jax.experimental import stax
+from jax.example_libraries import stax
 from jax.random import PRNGKey
 
 from jax_unirep.evotuning import evotune, fit

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,7 +1,7 @@
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from jax import random
-from jax.experimental import stax
+from jax.example_libraries import stax
 
 from jax_unirep.layers import AAEmbedding, mLSTM, mLSTMAvgHidden, mLSTMFusion
 from jax_unirep.utils import (


### PR DESCRIPTION
## PR Description

This PR refactors imports of a deprecated module (jax.experimental) within jax to use the current version (jax.example_libraries)
## Checklist

### General
1. [x] I have made the PR off a new branch from my fork 
   (`<your_username>`:`<feature-branch_name>`), *not* 
   `<your_username>`:`master`.
2. [x] I have added my changes to the `CHANGELOG.md` file at the top.
3. [x] I have made any necessary changes to the documentation in the `README`.

### Code checks
1. [x] If there are new features implemented, add suitable tests
   in the `tests` directory.
2. [x] If any new dependencies are introduced through the new features,
   add the packages, pinned to a version, to `environment.yml`.
3. [x] Run `make test` in a console in the top level directory
   to make sure all the tests pass.
4. [x] Run `make format` in a console in the top level directory
   to make the code comply with the formatting standards.
